### PR TITLE
User, Habit 엔티티 구성

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -30,6 +30,7 @@ dependencies {
     implementation 'mysql:mysql-connector-java'
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     implementation 'org.flywaydb:flyway-core:6.5.7'
+    implementation 'org.springframework.boot:spring-boot-starter-validation'
 
     compileOnly 'org.projectlombok:lombok'
     annotationProcessor 'org.projectlombok:lombok'

--- a/src/main/java/com/havit/havit/domain/habit/Habit.java
+++ b/src/main/java/com/havit/havit/domain/habit/Habit.java
@@ -1,0 +1,72 @@
+package com.havit.havit.domain.habit;
+
+import com.havit.havit.domain.user.User;
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.EnumType;
+import javax.persistence.Enumerated;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.JoinColumn;
+import javax.persistence.ManyToOne;
+import javax.persistence.PrePersist;
+import javax.validation.constraints.Max;
+import javax.validation.constraints.Min;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.DynamicInsert;
+
+@Entity
+@Getter
+@DynamicInsert
+@NoArgsConstructor
+public class Habit {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "habit_id", nullable = false)
+    private Long id;
+
+    @ManyToOne
+    @JoinColumn(name = "user_id")
+    private User user;
+
+    // 기본값은 빈 스트링
+    private String emoji;
+
+    // 기본값은 빈 스트링
+    private String name;
+
+    @Min(value = 1, message = "목표 횟수는 1과 같거나 1보다 커야 합니다.")
+    @Max(value = 7, message = "목표 횟수는 7과 같거나 7보다 작아야 합니다.")
+    @Column(name = "target_cnt")
+    // 기본값은 1
+    private int targetCnt;
+
+    // 기본값은 ACTIVE
+    @Enumerated(EnumType.STRING)
+    private Status status;
+
+    @PrePersist
+    public void prePersist() {
+        this.emoji = this.emoji == null ? "" : this.emoji;
+        this.name = this.name == null ? "" : this.name;
+        this.status = this.status == null ? Status.ACTIVE : this.status;
+    }
+
+    @Builder
+    public Habit(
+            User user,
+            String emoji,
+            String name,
+            int targetCnt,
+            String status
+    ) {
+        this.user = user;
+        this.emoji = emoji;
+        this.name = name;
+        this.targetCnt = targetCnt;
+        this.status = Status.getStatus(status);
+    }
+}

--- a/src/main/java/com/havit/havit/domain/habit/Status.java
+++ b/src/main/java/com/havit/havit/domain/habit/Status.java
@@ -1,0 +1,19 @@
+package com.havit.havit.domain.habit;
+
+import java.util.Objects;
+import lombok.Getter;
+
+@Getter
+public enum Status {
+    ACTIVE("ACTIVE"), INACTIVE("INACTIVE");
+
+    Status(String value) {
+        this.value = value;
+    }
+
+    public static Status getStatus(String status) {
+        return Objects.equals(status, ACTIVE.value) ? ACTIVE : INACTIVE;
+    }
+
+    private String value;
+}

--- a/src/main/java/com/havit/havit/domain/user/User.java
+++ b/src/main/java/com/havit/havit/domain/user/User.java
@@ -1,0 +1,55 @@
+package com.havit.havit.domain.user;
+
+import com.havit.havit.domain.habit.Habit;
+import java.util.ArrayList;
+import java.util.List;
+import javax.persistence.CascadeType;
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.JoinColumn;
+import javax.persistence.OneToMany;
+import javax.persistence.PrePersist;
+import javax.persistence.Table;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.DynamicInsert;
+
+@Entity
+@Getter
+@DynamicInsert
+@Table(name = "user")
+@NoArgsConstructor
+public class User {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "user_id", nullable = false)
+    private Long id;
+
+    private String slogan;
+
+    private String token;
+
+    private String provider;
+
+    @OneToMany(cascade = CascadeType.ALL)
+    @JoinColumn(name = "habit_id")
+    private List<Habit> habitList = new ArrayList<>();
+
+    @PrePersist
+    public void prePersist() {
+        this.slogan = this.slogan == null ? "" : this.slogan;
+    }
+
+    @Builder
+    public User(
+            String token,
+            String provider
+    ) {
+        this.token = token;
+        this.provider = provider;
+    }
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -2,13 +2,10 @@ spring.datasource.url=jdbc:mysql://localhost:3306/hav-it?autoReconnect=true
 spring.datasource.username=root
 spring.datasource.password=qwer1234
 spring.datasource.driver-class-name=com.mysql.cj.jdbc.Driver
-
 spring.flyway.locations=classpath:db/migration/
-
-spring.jpa.hibernate.ddl-auto=validate
+spring.jpa.hibernate.ddl-auto=none
 spring.jpa.generate-ddl=false
-
 spring.jpa.properties.hibernate.jdbc.lob.non_contextual_creation=true
 spring.flyway.enabled=true
-
-spring.flyway.baselineOnMigrate = true
+spring.flyway.baselineOnMigrate=true
+spring.jpa.properties.hibernate.show_sql=true

--- a/src/main/resources/db/migration/V1__init.sql
+++ b/src/main/resources/db/migration/V1__init.sql
@@ -1,0 +1,19 @@
+create table USER
+(
+    user_id bigint not null auto_increment,
+    provider varchar(255),
+    slogan varchar(255),
+    token varchar(255),
+    primary key (user_id));
+
+create table HABIT
+(
+    habit_id bigint not null auto_increment,
+    emoji varchar(255),
+    name varchar(255),
+    status varchar(255),
+    target_cnt integer,
+    user_id bigint,
+    primary key (habit_id),
+    foreign key (user_id) references user (user_id)
+);


### PR DESCRIPTION
### 요약
1. User 엔티티 구성
2. Habit 엔티티 구성

### 작업 내용
- user 엔티티 구성
- validation 관련 의존성 추가
- sql 문 확인할 수 있도록 show_sql 옵션 true
로 변경
- habit 엔티티 구성
- flyway 스크립트 생성 (user 과 habit 에 대해서)
- status enum 생성



### 관련 이슈
#4 #5  